### PR TITLE
Fix for play eclipsify

### DIFF
--- a/oauthclient/commands.py
+++ b/oauthclient/commands.py
@@ -2,14 +2,14 @@
 
 # Example below:
 # ~~~~
-if play_command == 'hello':
-	try:
-		print "~ Hello"
-		sys.exit(0)
-				
-	except getopt.GetoptError, err:
-		print "~ %s" % str(err)
-		print "~ "
-		sys.exit(-1)
-		
-	sys.exit(0)
+#if play_command == 'hello':
+#	try:
+#		print "~ Hello"
+#		sys.exit(0)
+#				
+#	except getopt.GetoptError, err:
+#		print "~ %s" % str(err)
+#		print "~ "
+#		sys.exit(-1)
+#		
+#	sys.exit(0)


### PR DESCRIPTION
play eclipsify fails because the default command.py doesn't work. I simply commented it out.
Someone else opened a bug about this a while ago:
http://play.lighthouseapp.com/projects/57987/tickets/552
